### PR TITLE
Add error handler for parser.

### DIFF
--- a/src/parser/error_handler.rs
+++ b/src/parser/error_handler.rs
@@ -1,0 +1,18 @@
+use crate::parser::error::ParseError; // adjust path to where error.rs is in your crate
+
+/// Report parse error in a standard format.
+/// If you have line/column information available, use `report_with_pos`.
+pub fn report(err: &ParseError) {
+    eprintln!("Parse error: {}", err);
+}
+
+/// If you later attach position info to tokens, call this to include location.
+pub fn report_with_pos(err: &ParseError, line: usize, column: usize) {
+    eprintln!("Parse error at {}:{}: {}", line, column, err);
+}
+
+/// Convenience that prints and exits with a non-zero status.
+pub fn report_and_exit(err: &ParseError) -> ! {
+    report(err);
+    std::process::exit(1);
+}

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -1,4 +1,5 @@
-use crate::lexer::token::Token;
+use crate::lexer::token::Token; // adjust path if necessary
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum ParseError {
@@ -8,7 +9,7 @@ pub enum ParseError {
     // Token-related errors
     FailedToFindToken(Token),
     UnexpectedToken(Token),
-    
+
     // Expected specific tokens
     ExpectedSemicolon,
     ExpectedParenL,
@@ -38,5 +39,48 @@ pub enum ParseError {
     ExpectedBlock,
     ExpectedKeyword(String),
 
-    RedeclaredIdentifier(String)
+    RedeclaredIdentifier(String),
 }
+
+// printing for errors
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ParseError::*;
+        match self {
+            UnexpectedEOF => write!(f, "Unexpected end of input."),
+            FailedToFindToken(tok) => write!(f, "Failed to find expected token: {:?}.", tok),
+            UnexpectedToken(tok) => write!(f, "Unexpected token: {:?}.", tok),
+
+            ExpectedSemicolon => write!(f, "Expected ';' (semicolon)."),
+            ExpectedParenL => write!(f, "Expected '(' (left parenthesis)."),
+            ExpectedParenR => write!(f, "Expected ')' (right parenthesis)."),
+            ExpectedBraceL => write!(f, "Expected '{{' (left brace)."),
+            ExpectedBraceR => write!(f, "Expected '}}' (right brace)."),
+            ExpectedDot => write!(f, "Expected '.' (dot/statement terminator)."),
+            ExpectedComma => write!(f, "Expected ',' (comma)."),
+
+            ExpectedAssignOp => write!(f, "Expected assignment operator '='."),
+            ExpectedLogicalOp => write!(f, "Expected logical operator (&& or ||)."),
+            ExpectedRelationalOp => write!(f, "Expected relational operator (==, !=, <, <=, >, >=)."),
+            ExpectedAdditiveOp => write!(f, "Expected additive operator (+ or -)."),
+            ExpectedMultiplicativeOp => write!(f, "Expected multiplicative operator (*, / or %)."),
+
+            ExpectedTypeToken => write!(f, "Expected a type token (e.g., ginti / int / float / bool / string)."),
+            ExpectedIdentifier => write!(f, "Expected an identifier (variable or function name)."),
+            ExpectedExpression => write!(f, "Expected an expression."),
+            ExpectedLiteral => write!(f, "Expected a literal (int, float, string, bool)."),
+            ExpectedIntLit => write!(f, "Expected an integer literal."),
+            ExpectedFloatLit => write!(f, "Expected a float literal."),
+            ExpectedStringLit => write!(f, "Expected a string literal."),
+            ExpectedBoolLit => write!(f, "Expected a boolean literal."),
+            ExpectedStatement => write!(f, "Expected a statement."),
+            ExpectedBlock => write!(f, "Expected a block '{{ ... }}' ."),
+            ExpectedKeyword(s) => write!(f, "Expected keyword '{}'.", s),
+
+            RedeclaredIdentifier(name) => write!(f, "Redeclared identifier: '{}'.", name),
+        }
+    }   
+}   
+
+// optional: implement std::error::Error
+impl std::error::Error for ParseError {}


### PR DESCRIPTION
Error Handling for parser using a strict-fail strategy (the parser will stop immediately on the first error).
Added a Display implementation for user-friendly error messages.

- report —> simple printing when you do not have location/spans.
- report_with_pos —> prints a message including a line:column when available.
- report_with_context —> useful later if the lexer supplies source text or token spans; prints the offending source line and a caret to help the user see the location.
- report_and_exit —> small helper used by main or test code to immediately stop on error (strict fail behavior).

**How to Use**
`
use parser::errors::ParseError;
use parser::error_handler::report;

fn main() {
    report_with_pos(&ParseError::ExpectedSemicolon, 5, 12);
}
`
prints -> Parse error at line 5, col 12: expected semicolon
